### PR TITLE
Fix debug output character

### DIFF
--- a/de.czempin.nicnac16.compiler/src/de/czempin/nicnac16/compiler/Main.java
+++ b/de.czempin.nicnac16.compiler/src/de/czempin/nicnac16/compiler/Main.java
@@ -122,7 +122,7 @@ public class Main {
 				break;
 			default:
 				String punctuation = strt.toString().substring(7, 8); // crude way to extract brackets etc.
-				System.out.println("°" + punctuation);
+				System.out.println(punctuation);
 				if ("(".equals(punctuation)) {
 					switch (ps) {
 					case DECLARATION:


### PR DESCRIPTION
## Summary
- remove unexpected character in debug output

## Testing
- `javac -classpath de.czempin.nicnac16.compiler/lib/guava-18.0.jar @sources.txt` *(fails: interface expected here)*